### PR TITLE
GPU ROM passthrough fixes

### DIFF
--- a/patches.misc/0001-xen-pciback-Fix-error-return-in-bar_write-and-rom_wr.patch
+++ b/patches.misc/0001-xen-pciback-Fix-error-return-in-bar_write-and-rom_wr.patch
@@ -1,0 +1,84 @@
+From 80eba9bc4c92cabbf2480845ba9d053c2160ee85 Mon Sep 17 00:00:00 2001
+From: Dwayne Litzenberger <dlitz@dlitz.net>
+Date: Wed, 11 Jan 2017 03:34:40 -0800
+Subject: [PATCH 1/2] xen-pciback: Fix error return in bar_write() and
+ rom_write()
+
+Signed-off-by: Dwayne Litzenberger <dlitz@dlitz.net>
+---
+ drivers/xen/xen-pciback/conf_space_header.c | 24 ++++++++++++++++++------
+ 1 file changed, 18 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/xen/xen-pciback/conf_space_header.c b/drivers/xen/xen-pciback/conf_space_header.c
+index 5fbfd9c..153c91d 100644
+--- a/drivers/xen/xen-pciback/conf_space_header.c
++++ b/drivers/xen/xen-pciback/conf_space_header.c
+@@ -134,6 +134,7 @@ static int command_write(struct pci_dev *dev, int offset, u16 value, void *data)
+ 
+ static int rom_write(struct pci_dev *dev, int offset, u32 value, void *data)
+ {
++	int err = 0;
+ 	struct pci_bar_info *bar = data;
+ 
+ 	if (unlikely(!bar)) {
+@@ -149,17 +150,22 @@ static int rom_write(struct pci_dev *dev, int offset, u32 value, void *data)
+ 		bar->which = 1;
+ 	else {
+ 		u32 tmpval;
+-		pci_read_config_dword(dev, offset, &tmpval);
++		err = pci_read_config_dword(dev, offset, &tmpval);
++		if (err)
++			goto out;
+ 		if (tmpval != bar->val && value == bar->val) {
+ 			/* Allow restoration of bar value. */
+-			pci_write_config_dword(dev, offset, bar->val);
++			err = pci_write_config_dword(dev, offset, bar->val);
++			if (err)
++				goto out;
+ 		}
+ 		bar->which = 0;
+ 	}
+ 
+ 	/* Do we need to support enabling/disabling the rom address here? */
+ 
+-	return 0;
++out:
++	return err;
+ }
+ 
+ /* For the BARs, only allow writes which write ~0 or
+@@ -168,6 +174,7 @@ static int rom_write(struct pci_dev *dev, int offset, u32 value, void *data)
+  */
+ static int bar_write(struct pci_dev *dev, int offset, u32 value, void *data)
+ {
++	int err = 0;
+ 	struct pci_bar_info *bar = data;
+ 
+ 	if (unlikely(!bar)) {
+@@ -183,15 +190,20 @@ static int bar_write(struct pci_dev *dev, int offset, u32 value, void *data)
+ 		bar->which = 1;
+ 	else {
+ 		u32 tmpval;
+-		pci_read_config_dword(dev, offset, &tmpval);
++		err = pci_read_config_dword(dev, offset, &tmpval);
++		if (err)
++			goto out;
+ 		if (tmpval != bar->val && value == bar->val) {
+ 			/* Allow restoration of bar value. */
+-			pci_write_config_dword(dev, offset, bar->val);
++			err = pci_write_config_dword(dev, offset, bar->val);
++			if (err)
++				goto out;
+ 		}
+ 		bar->which = 0;
+ 	}
+ 
+-	return 0;
++out:
++	return err;
+ }
+ 
+ static int bar_read(struct pci_dev *dev, int offset, u32 * value, void *data)
+-- 
+2.7.4
+

--- a/patches.misc/0002-xen-pciback-Allow-enabling-disabling-expansion-ROM.patch
+++ b/patches.misc/0002-xen-pciback-Allow-enabling-disabling-expansion-ROM.patch
@@ -1,0 +1,48 @@
+From b5588aaec29ea5d5a344e74023eb6e6df6c3ec49 Mon Sep 17 00:00:00 2001
+From: Dwayne Litzenberger <dlitz@dlitz.net>
+Date: Wed, 11 Jan 2017 03:34:49 -0800
+Subject: [PATCH 2/2] xen-pciback: Allow enabling/disabling expansion ROM
+
+Signed-off-by: Dwayne Litzenberger <dlitz@dlitz.net>
+---
+ drivers/xen/xen-pciback/conf_space_header.c | 20 ++++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/xen/xen-pciback/conf_space_header.c b/drivers/xen/xen-pciback/conf_space_header.c
+index 153c91d..5a83b27 100644
+--- a/drivers/xen/xen-pciback/conf_space_header.c
++++ b/drivers/xen/xen-pciback/conf_space_header.c
+@@ -150,20 +150,20 @@ static int rom_write(struct pci_dev *dev, int offset, u32 value, void *data)
+ 		bar->which = 1;
+ 	else {
+-		u32 tmpval;
+-		err = pci_read_config_dword(dev, offset, &tmpval);
++		u32 newval = bar->val;
++
++		/* Allow enabling/disabling rom, if present */
++		if (newval & PCI_ROM_ADDRESS_MASK) {
++			newval &= ~PCI_ROM_ADDRESS_ENABLE;
++			newval |= value & PCI_ROM_ADDRESS_ENABLE;
++		}
++
++		err = pci_write_config_dword(dev, offset, newval);
+ 		if (err)
+ 			goto out;
+-		if (tmpval != bar->val && value == bar->val) {
+-			/* Allow restoration of bar value. */
+-			err = pci_write_config_dword(dev, offset, bar->val);
+-			if (err)
+-				goto out;
+-		}
++		bar->val = newval;
+ 		bar->which = 0;
+ 	}
+ 
+-	/* Do we need to support enabling/disabling the rom address here? */
+-
+ out:
+ 	return err;
+ }
+-- 
+2.7.4
+

--- a/patches.xen/pvops-blkfront-removable-flag.patch
+++ b/patches.xen/pvops-blkfront-removable-flag.patch
@@ -21,5 +21,5 @@ index 4e86393..34493d7 100644
 +		binfo |= VDISK_REMOVABLE;
 +
  	err = xlvbd_alloc_gendisk(sectors, info, binfo, sector_size,
-				  physical_sector_size);
+ 				  physical_sector_size);
  	if (err) {

--- a/series.conf
+++ b/series.conf
@@ -22,3 +22,7 @@ patches.xen/xsa155-linux44-0013-xen-blkfront-prepare-request-locally-only-then-p
 
 # MSI-X enabled device passthrough fix (#1734)
 patches.xen/pci_op-cleanup.patch
+
+# Upstreamable patches
+patches.misc/0001-xen-pciback-Fix-error-return-in-bar_write-and-rom_wr.patch
+patches.misc/0002-xen-pciback-Allow-enabling-disabling-expansion-ROM.patch


### PR DESCRIPTION
With this, I can attach a Radeon HD 6870 GPU to a HVM running Debian and play OpenArena on it.  It's delicate and there are still other bugs, but I got it working.

These patches also work against the stable-4.4 (v4.4.38-11) kernel.